### PR TITLE
Make test selection configurable

### DIFF
--- a/src/main/scala/tools/partest/TestingInterface.scala
+++ b/src/main/scala/tools/partest/TestingInterface.scala
@@ -72,7 +72,7 @@ case class SbtPartestTask(taskDef: TaskDef) extends Task {
     if (Runtime.getRuntime().maxMemory() / (1024*1024) < 800)
       loggers foreach (_.warn(s"""Low heap size detected (~ ${Runtime.getRuntime().maxMemory() / (1024*1024)}M). Please add the following to your build.sbt: javaOptions in Test += "-Xmx1G""""))
 
-    try runner execute Array("scalacheck", "instrumented", "pos", "neg", "run", "jvm", "res", "scalap", "specialized", "presentation")
+    try runner execute taskDef.selectors.collect{case ts: sbt.testing.TestSelector => ts.testName.split(" ")}.flatten
     catch {
       case ex: ClassNotFoundException =>
         loggers foreach { l => l.error("Please make sure partest is running in a forked VM by including the following line in build.sbt:\nfork in Test := true") }


### PR DESCRIPTION
This proposed change allows the usual partest specification string to be passed via the Selectors argument, so something like this can be written to run the subset of tests in instrumented, pos, and neg:

````
    definedTests in Test += (
      new sbt.TestDefinition(
        "partest",
        // marker fingerprint since there are no test classes
        // to be discovered by sbt:
        new sbt.testing.AnnotatedFingerprint {
          def isModule = true
          def annotationName = "partest"
        }, true, Array(new sbt.testing.TestSelector("instrumented pos neg")))
````
